### PR TITLE
manage img alignment

### DIFF
--- a/sass/base/_layout.scss
+++ b/sass/base/_layout.scss
@@ -31,6 +31,14 @@ a{
 	outline-width: 0;
 	color: $color-main;
 }
+
+.basic-alignment {
+  &.left { float: left; margin-right: 1.5em; }
+  &.right { float: right; margin-left: 1.5em; }
+  &.center { display:block; margin: 0 auto 1.5em; }
+  &.left, &.right { margin-bottom: .8em; }
+}
+
 .alignleft{
 	float: left;
 }

--- a/sass/parts/_article.scss
+++ b/sass/parts/_article.scss
@@ -71,6 +71,7 @@ article{
 		img, video{
 			max-width: 100%;
 			height: auto;
+			@extend .basic-alignment;
 		}
 		blockquote{
 			background: $color-gray04;


### PR DESCRIPTION
I've added the "basic-alignment" class from default octopress theme.
This is useful to manage align, and this is compatible with the standard img tag octopress plugin doc:  http://octopress.org/docs/plugins/image-tag/
