### PR TITLE
Add Schema.org markup to blog posts

### DIFF
--- a/source/_includes/archive_post.html
+++ b/source/_includes/archive_post.html
@@ -7,14 +7,14 @@
 	{% endunless %}
 	<section class="archives"><h1 class="year">{{ date | date: "%Y" }}</h1>
 {% endunless %}
-<article>
+<article itemprop="blogPost" itemscope itemtype="http://schema.org/BlogPosting">
 	<div class="meta">
-		<span class="date">{{ date | date: "%b %e" }}</span>
+		<span class="date"><time datetime="{{ date | datetime | date_to_xmlschema }}" itemprop="datePublished">{{ date | date: "%b %e" }}</time></span>
 		<br>
 		<span class="tags">{% include post/categories.html %}</span>
 	    {% if site.disqus_short_name and post.comments == true and site.disqus_show_comment_count == true %}
 	    <span class="comments"><a href="{{ root_url }}{{ post.url }}#disqus_thread">Comments</a></span>
 	    {% endif %}
 	</div>
-	<h1 class="title"><a href="{{ root_url }}{{ post.url }}">{{post.title}}</a></h1>
+	<h1 class="title" itemprop="name"><a href="{{ root_url }}{{ post.url }}">{{post.title}}</a></h1>
 </article>

--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -6,13 +6,13 @@
 			<span class="comments"><a href="{{ root_url }}{{ post.url }}#disqus_thread">Comments</a></span>
 		{% endif %}
 	</div>
-	<h1 class="title"><a href="{{ root_url }}{{ post.url }}">{% if site.titlecase %}{{ post.title | titlecase }}{% else %}{{ post.title }}{% endif %}</a></h1>
-	<div class="entry-content">
+	<h1 class="title" itemprop="name"><a href="{{ root_url }}{{ post.url }}" itemprop="url">{% if site.titlecase %}{{ post.title | titlecase }}{% else %}{{ post.title }}{% endif %}</a></h1>
+	<div class="entry-content" itemprop="articleBody">
 		{{ content | excerpt }}
 		{% capture excerpted %}{{ content | has_excerpt }}{% endcapture %}
 		{% if excerpted == 'true' %}<a href="{{ root_url }}{{ post.url }}" class="more-link">{{ site.excerpt_link }}</a>{% endif %}
 	</div>
 {% else %}
-	<h1 class="title">{% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title }}{% endif %}</h1>
-	<div class="entry-content">{{ content }}</div>
+	<h1 class="title" itemprop="name">{% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title }}{% endif %}</h1>
+	<div class="entry-content" itemprop="articleBody">{{ content }}</div>
 {% endif %}

--- a/source/_includes/post/date.html
+++ b/source/_includes/post/date.html
@@ -7,9 +7,9 @@
 {% capture was_updated %}{{ updated | size }}{% endcapture %}
 
 {% if has_date != '0' %}
-  {% capture time %}<time datetime="{{ date | datetime | date_to_xmlschema }}" pubdate{% if updated %} data-updated="true"{% endif %}>{{ date_formatted }}</time>{% endcapture %}
+  {% capture time %}<time datetime="{{ date | datetime | date_to_xmlschema }}" pubdate{% if updated %} data-updated="true"{% endif %} itemprop="datePublished">{{ date_formatted }}</time>{% endcapture %}
 {% endif %}
 
 {% if was_updated != '0' %}
-  {% capture updated %}<time datetime="{{ updated | datetime | date_to_xmlschema }}" class="updated">Updated {{ updated_formatted }}</time>{% endcapture %}
+  {% capture updated %}<time datetime="{{ updated | datetime | date_to_xmlschema }}" class="updated" itemprop="dateModified">Updated {{ updated_formatted }}</time>{% endcapture %}
 {% else %}{% assign updated = false %}{% endif %}

--- a/source/_includes/post/date.html
+++ b/source/_includes/post/date.html
@@ -7,7 +7,7 @@
 {% capture was_updated %}{{ updated | size }}{% endcapture %}
 
 {% if has_date != '0' %}
-  {% capture time %}<time datetime="{{ date | datetime | date_to_xmlschema }}" pubdate{% if updated %} data-updated="true"{% endif %} itemprop="datePublished">{{ date_formatted }}</time>{% endcapture %}
+  {% capture time %}<time datetime="{{ date | datetime | date_to_xmlschema }}" {% if updated %}data-updated="true"{% endif %} itemprop="datePublished">{{ date_formatted }}</time>{% endcapture %}
 {% endif %}
 
 {% if was_updated != '0' %}

--- a/source/_layouts/post.html
+++ b/source/_layouts/post.html
@@ -3,7 +3,7 @@ layout: default
 single: true
 ---
 
-<article class="post">{% include article.html %}</article>
+<article class="post" itemscope itemtype="http://schema.org/BlogPosting">{% include article.html %}</article>
 {% unless page.sharing == false %}
 	{% include post/sharing.html %}
 {% endunless %}

--- a/source/blog/archives/index.html
+++ b/source/blog/archives/index.html
@@ -3,6 +3,8 @@ layout: default
 title: Blog Archives
 ---
 
+<div itemscope itemtype="http://schema.org/Blog">
 {% for post in site.posts reverse %}
 	{% include archive_post.html %}
 {% endfor %}
+</div>

--- a/source/index.html
+++ b/source/index.html
@@ -3,10 +3,12 @@ layout: default
 ---
 
 {% assign index = true %}
+<div itemscope itemtype="http://schema.org/Blog">
 {% for post in paginator.posts %}
 {% assign content = post.content %}
-    <article class="post">{% include article.html %}</article>
+    <article class="post" itemprop="blogPost" itemscope itemtype="http://schema.org/BlogPosting">{% include article.html %}</article>
 {% endfor %}
+</div>
 <nav id="pagenavi">
     {% if paginator.previous_page %}
         <a href="{{paginator.previous_page}}" class="prev">Prev</a>


### PR DESCRIPTION
The main search engines (Google, Bing, Yahoo) use mircodata for rich snippets in their search results. They use the [Schema.org](http://schema.org/) markup.

This PR adds the necessary microdata to blog postings. I validated the output using Google's [Structured Data Testing Tool](https://www.google.com/webmasters/tools/richsnippets)

I also removed the pubDate attribute from time tags. Its been removed from the HTML5 spec and was the only thing stopping full HTML5 validation.
