### PR TITLE
Downcase email before hashing

### DIFF
--- a/source/_includes/header.html
+++ b/source/_includes/header.html
@@ -1,7 +1,7 @@
 <div class="profilepic">	
 	<script src="{{ root_url }}/javascripts/md5.js"></script>
 	<script type="text/javascript">
-		document.write("<img src='http://www.gravatar.com/avatar/" + MD5("{{ site.email }}") + "?s=160' alt='Profile Picture' style='width: 160px;'");
+		document.write("<img src='http://www.gravatar.com/avatar/" + MD5("{{ site.email | downcase }}") + "?s=160' alt='Profile Picture' style='width: 160px;'");
 	</script>
 </div>
 <h1><a href="{{ root_url }}/">{{ site.title }}</a></h1>


### PR DESCRIPTION
According to the Gravatar docs, all emails should be converted to all
lowercase before hashing.

See: http://en.gravatar.com/site/implement/hash/
