### PR TITLE
Fixed weird padding in archives' comments count span

### DIFF
--- a/sass/parts/_archive.scss
+++ b/sass/parts/_archive.scss
@@ -67,7 +67,7 @@
 			}
 			.date:before{content: "\f073";}
 			.tags:before{content: "\f02c";}
-			.comments:before{content: "\f075";}
+			.comments:before{content: "\f075"; padding-right: 10px; }
 		}
 	}
 }


### PR DESCRIPTION
First of all, I want to thank you for the effort you put on this theme.
It's awesome and it looks like I'm going to be using it for a long while!

I'm seeing some weird padding in the comments count in the archives page.
I noticed that since your blog archive doesn't display comment counts, I guess you missed that somehow.

Here's what it looked before:
![image](https://f.cloud.github.com/assets/1674699/469328/e69580c2-b6be-11e2-930c-6a223fb148bc.png)

And after this fix:
![image](https://f.cloud.github.com/assets/1674699/469343/f8cf3a16-b6bf-11e2-8456-2df8943cd9b3.png)

Hope it helps!
