### PR TITLE
added hr styling to post page

### DIFF
--- a/sass/parts/_post.scss
+++ b/sass/parts/_post.scss
@@ -40,4 +40,13 @@
 		.tags:before{content: "\f02c";}
 		.comments:before{content: "\f075";}
 	}
+  hr{
+		height: 0;
+		margin-top: 20px;
+		margin-bottom: 20px;
+		border-left: 0;
+		border-right: 0;
+		border-top: 1px solid #DDD;
+		border-bottom: 1px solid #FFF;
+	}
 }


### PR DESCRIPTION
Hello Shashank

Loving your theme, I've shown it to a few friends of mine and they went nuts!

Just another small change I've made to my copy of the theme and I think it would be useful for everyone else.

The `hr` is unstyled, noticed when using it via markdown (`---` on a blank line) and I've decided to fix by applying the same colors as the top/bottom borders of `article` and `div.share`, for example, to preserve the look 'n' feel.

Here's how it was before the fix:

Before:
![image](https://f.cloud.github.com/assets/1674699/486388/fdf208fe-b91f-11e2-9fec-eb16909e84ca.png)

After:
![image](https://f.cloud.github.com/assets/1674699/486403/e09c716c-b920-11e2-9f2c-b0f15f2ec73c.png)

Hope you like it

Thanks again!
