### PR TITLE
Updates to twitter.js

### DIFF
--- a/source/javascripts/twitter.js
+++ b/source/javascripts/twitter.js
@@ -66,11 +66,13 @@
 					fragment.appendChild(item);
 				}
 
-				var play = function(){
+				var play = function(){				
 					timeout = setTimeout(function(){
-						feed.animate({top: '-='+30}, speed, function(){
-							$(this).append($(this).children().eq(counts).clone());
-							counts++;
+						feed.animate({top: -30}, speed, function(){
+							//move the first item and put it as last item
+							$(this).children('li:last').after($(this).children('li:first'));
+							//set the default item to correct position
+							$(this).css({'top' : '0px'});
 							play();
 						});
 					}, interval);

--- a/source/javascripts/twitter.js
+++ b/source/javascripts/twitter.js
@@ -52,7 +52,7 @@
 		}
 
 		if ($(window).width() > 600){
-			var url = 'https://api.twitter.com/1/statuses/user_timeline/'+userid+'.json?count='+count+'&exclude_replies='+(reply ? '0' : '1')+'&trim_user=true&callback=?';
+			var url = 'https://api.twitter.com/1/statuses/user_timeline.json?screen_name='+userid+'&count='+count+'&include_rts=true&trim_user=true&exclude_repies='+(reply ? '0' : '1')+'&callback=?';
 			banner.show();
 			$.getJSON(url, function(json){
 				var length = json.length,


### PR DESCRIPTION
Seems that old url only returned one tweet even though having configured twitter_tweet_count variable to a greater value. The url has been updated according to Twitter API documentation: https://dev.twitter.com/docs/api/1.1/get/statuses/user_timeline

In addition, jquery animate function was creating infinite list elements. Its callback has been updated to avoid this behavior.
