### PR TITLE
Allow user to provide MD5 hash for Gravatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Starting point forked from [Slash](https://github.com/tommy351/Octopress-Theme-S
 
 1. Responsive design.
 1. Fancybox integration
-1. Gravatar support thanks to [Zhigang Fang](https://github.com/zhigang1992). Add your email id to `_config.yml` and your profile picture will appear in the left nav. 
+1. Gravatar support thanks to [Zhigang Fang](https://github.com/zhigang1992). Add your email id to `_config.yml` and your profile picture will appear in the left nav. If you don't want your email to be visible in the HTML code, you can provide the MD5 hashed value of your email as [expected](https://gravatar.com/site/implement/hash/) by Gravatar with an `email_md5` entry in `_config.yml`
 1. [Schema.org](http://schema.org/) support thanks to [Nathan Shaughnessy](https://github.com/nathanshox)
 
 ##Conditions 

--- a/source/_includes/header.html
+++ b/source/_includes/header.html
@@ -1,10 +1,14 @@
 <div class="profilepic">
+	{% if site.email_md5 %}
+	<img src="http://www.gravatar.com/avatar/{{ site.email_md5 }}?s=160" alt="Profile Picture" style="width: 160px;" />
+	{% else %}
 	<script src="{{ root_url }}/javascripts/md5.js"></script>
 	<script type="text/javascript">
 		$(function(){
 			$('.profilepic').append("<img src='http://www.gravatar.com/avatar/" + MD5("{{ site.email | downcase }}") + "?s=160' alt='Profile Picture' style='width: 160px;' />");
 		});
 	</script>
+	{% endif %}
 </div>
 {% include custom/header.html %}
 <nav id="main-nav">{% include navigation.html %}</nav>


### PR DESCRIPTION
Calculating the Gravatar URL based on the email address
in Javascript is convenient, but having the email address
in plaintext in the resulting HTML file might not be what
everybody wants.

This adds support for providing the MD5 hash value via
the email_md5 entry in _config.yml.

As a side-effect, we don't need to include md5.js if the
hash value is already known.
