### PR TITLE
changed max-width of css3 switch for better looking in new ipad (or later).

### DIFF
--- a/sass/_greyshade.scss
+++ b/sass/_greyshade.scss
@@ -273,7 +273,7 @@ body {
 			margin: 0 0;
 	}
 }
-@media screen and (max-width: 700px){
+@media screen and (max-width: 830px){
 	.container {
 		.credit-box {
 			display: none;


### PR DESCRIPTION
 When max-width is 700px, the navigtion area is in the left side
of screen and very narrow. Changing max-width to 830px , as i tried,
which is best suitable, could make navigation area in the upper of the
screen in new ipad (or later).

picture when max-width is 700px:
![before](http://landerlyoung.github.io/assets/storage/for_ipad_before.jpg)
picture after max-width adjusted to 830px:
![after](http://landerlyoung.github.io/assets/storage/for_ipad_after.jpg)
