### PR TITLE
[Fix] Include the after_footer.html in the default layout

### DIFF
--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -18,5 +18,6 @@
 			<footer id="footer" class="inner">{% include footer.html %}</footer>
 		</div>
 	</div>
+	{% include after_footer.html %}
 </body>
 </html>


### PR DESCRIPTION
after_footer.html was never called, which means that some library's specific scripts were never included.

Because of this, the Disqus feature was not working despite of the proper configuration.

I have put the call just before the closing of the body, as after_footer normally includes `<script></script>` calls.

The following scripts are included by default:

```
{% include disqus.html %}
{% include facebook_like.html %}
{% include google_plus_one.html %}
{% include twitter_sharing.html %}
{% include custom/after_footer.html %}
```

See also the classic theme: 
- [Classic after_footer.html](https://github.com/imathis/octopress/blob/master/.themes/classic/source/_includes/after_footer.html)
- [Classic default.html](https://github.com/imathis/octopress/blob/master/.themes/classic/source/_layouts/default.html)
