### PR TITLE
Update category_feed.xml

### DIFF
--- a/source/_includes/custom/category_feed.xml
+++ b/source/_includes/custom/category_feed.xml
@@ -21,7 +21,7 @@ layout: nil
     <link href="{{ site.url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>
-    <content type="html"><![CDATA[{{ post.content | expand_urls: site.url | markdownify | cdata_escape }}]]></content>
+    <content type="html"><![CDATA[{{ post.content | expand_urls: site.url | markdownize | cdata_escape }}]]></content>
   </entry>
   {% endfor %}
 </feed>


### PR DESCRIPTION
Fixes Liquid Exception: Tag '{%%20post_url%xxx%20%}' was not properly terminated with regexp: /\%}/ in blog/categories/xxx/atom.xml
